### PR TITLE
Avoid lock copy

### DIFF
--- a/any/any.go
+++ b/any/any.go
@@ -71,10 +71,10 @@ func GetMessageName(m []byte) (string, error) {
 	return splits[len(splits)-1], nil
 }
 
-func getEnvelope(m []byte) (pb.Envelope, error) {
+func getEnvelope(m []byte) (*pb.Envelope, error) {
 	var receivingEnvelope pb.Envelope
 
 	err := proto.Unmarshal(m, &receivingEnvelope)
 
-	return receivingEnvelope, err
+	return &receivingEnvelope, err
 }


### PR DESCRIPTION
Linter is showing the following warning:
```
return copies lock value: github.com/vimeda/pletter/pb.Envelope contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
```

Returning the envelope as a pointer would prevent this.